### PR TITLE
Merge fields from static and dynamic filters

### DIFF
--- a/src/main/java/com/jfilter/components/FilterAdvice.java
+++ b/src/main/java/com/jfilter/components/FilterAdvice.java
@@ -77,7 +77,7 @@ public final class FilterAdvice implements ResponseBodyAdvice<Object> {
     public Serializable beforeBodyWrite(Object obj, MethodParameter methodParameter, MediaType mediaType,
                                         Class<? extends HttpMessageConverter<?>> aClass, ServerHttpRequest serverHttpRequest,
                                         ServerHttpResponse serverHttpResponse) {
-        FilterFields filterFields;
+        FilterFields filterFields = FilterFields.EMPTY_FIELDS;
 
         //Getting HttpServletRequest from serverHttpRequest
         HttpServletRequest servletServerHttpRequest = ((ServletServerHttpRequest) serverHttpRequest).getServletRequest();
@@ -88,10 +88,11 @@ public final class FilterAdvice implements ResponseBodyAdvice<Object> {
         if (filter != null) {
             //Get fields from static filter
             filterFields = filter.getFields(obj, requestSession);
-        } else {
-            //Get fields from dynamic filter
-            filterFields = dynamicFilterProvider.getFields(methodParameter, requestSession);
         }
+
+        //Get fields from dynamic filter
+        FilterFields dynamicFilterFields = dynamicFilterProvider.getFields(methodParameter, requestSession);
+        dynamicFilterFields.getFieldsMap().forEach(filterFields::appendToMap);
 
         MethodParameterDetails methodParameterDetails = new MethodParameterDetails(methodParameter, mediaType, filterFields);
 


### PR DESCRIPTION
This PR enables merging fields to be filtered from both static and dynamic filters i.e. it is possible to have both `@FieldFilterSetting` and `@DynamicFilter` annotations on the same endpoint. For more information see #16 

Note: Some tests are failing, when all of them are executed at once, but they always pass when executed separately, so it is a test issue, not a functional one.